### PR TITLE
Release GIL for python interface

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -30,18 +30,25 @@ fn edge_list_to_vector(edge_list: &EdgeList<FilteredEdge<OneCriticalGrade<Ordere
     edges
 }
 
-#[pyfunction]
-fn remove_strongly_filtration_dominated(edges: Vec<BifilteredEdge>) -> PyResult<Vec<BifilteredEdge>> {
+fn remove_strongly_filtration_dominated_original(edges: Vec<BifilteredEdge>) -> PyResult<Vec<BifilteredEdge>> {
     let mut edge_list = vector_to_edge_list(edges);
     let reduced = ::filtration_domination::removal::remove_strongly_filtration_dominated(&mut edge_list, EdgeOrder::ReverseLexicographic);
     Ok(edge_list_to_vector(&reduced))
 }
 
 #[pyfunction]
-fn remove_filtration_dominated(edges: Vec<BifilteredEdge>) -> PyResult<Vec<BifilteredEdge>> {
+fn remove_strongly_filtration_dominated(py: Python<'_>, edges: Vec<BifilteredEdge>) -> PyResult<Vec<BifilteredEdge>> {
+    py.allow_threads(|| remove_strongly_filtration_dominated_original(edges))
+}
+
+fn remove_filtration_dominated_original(edges: Vec<BifilteredEdge>) -> PyResult<Vec<BifilteredEdge>> {
     let mut edge_list = vector_to_edge_list(edges);
     let reduced = ::filtration_domination::removal::remove_filtration_dominated(&mut edge_list, EdgeOrder::ReverseLexicographic);
     Ok(edge_list_to_vector(&reduced))
+}
+#[pyfunction]
+fn remove_filtration_dominated(py: Python<'_>, edges: Vec<BifilteredEdge>) -> PyResult<Vec<BifilteredEdge>> {
+    py.allow_threads(|| remove_filtration_dominated_original(edges))
 }
 
 #[pyfunction]
@@ -54,7 +61,7 @@ fn gaussian_density_estimation(points: Vec<(f64, f64)>, bandwidth: f64) -> PyRes
 }
 
 #[pymodule]
-fn filtration_domination(_py: Python, m: &PyModule) -> PyResult<()> {
+fn filtration_domination(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     let utils = PyModule::new(_py, "utils")?;
     utils.add_function(wrap_pyfunction!(gaussian_density_estimation, m)?)?;
     m.add_submodule(utils)?;


### PR DESCRIPTION
Hello Ángel,

I just did a small optimization for the python part, which allows `remove_filtration_dominated` to be used in a parallel context in python.

It's basically a wrapping of your python interface, which releases the python's Global Interpreter Lock while doing computations in rust. I'm not a Rust expert at all, so it may be done in better ways; I just followed the [documentation of pyo3](https://pyo3.rs/v0.18.3/parallelism) to achieve this. I didn't tested much how much performance we gain, but it seemed to perform well with this patch

The only caveat I'm aware of, is that you have to make sure to not modify the (rust) edges in python while rust code is running, but I don't see in which context one would want that (or how to achieve that).

What do you think about it ? 
Don't hesitate to edit my branch if you will :wink: 
David