### PR TITLE
add python 3.13

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         target: [x86_64, universal2-apple-darwin]
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         target: [x64, x86]
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         target: [x86_64, i686]
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
I'm starting to update `multipers` to python 3.13 as `gudhi` should be fine as well.  
Works well already from sources (at least on linux). I haven't tested to bump the rust dependencies versions.